### PR TITLE
Upgrade testing to more recent WebDriverIO docs

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -3,33 +3,37 @@
 Acos features browser tests using WebDriverIO. Quick steps to setup testing
 environment and run tests:
 
-  1. Install WebDriverIO: `npm install webdriverio`
-  2. Install Selenium server from http://docs.seleniumhq.org/download/
-  3. Run Selenium server:
-    `java -jar /path/to/selenium-server-standalone-2.XX.X.jar`
-  4. Install webdrivers for the desired browsers, e.g. [Chrome webdriver](https://sites.google.com/a/chromium.org/chromedriver/downloads)
-  5. Start Acos server `node bin/www`
-  6. Run tests in Acos folder:
-    `./node_modules/webdriverio/bin/wdio wdio.conf.js`
+  1. If `npm install` correctly installed `devDependencies` you are good to run
+    tests inside Chrome browser. Else look into Configuring Tests section.
+  2. Start Acos server
+    `node bin/www`
+  3. Run tests in Acos folder:
+    `./node_modules/.bin/wdio`
 
 You can also run individual tests/suites, e.g.
-`wdio wdio.conf.js --mochaOpts.grep 'ps_hello'` would run tests that match with
-`ps_hello`
+`./node_modules/.bin/wdio --mochaOpts.grep 'ps_hello'`
+would run tests that match with `ps_hello`.
 
 For more detailed on getting started with WebDriverIO,
-see http://webdriver.io/guide/getstarted/install.html
+see https://webdriver.io/docs/gettingstarted.html
 
 # Configuring Tests
 
-Configuration for tests is found in `wdio.conf.js`. The most relevant settings
-are the `baseUrl` (default `http://localhost:3000`) and `capabilities` that
-defines the browser to use (by default Chrome).
+WebDriverIO CLI handles configuring and installing dependencies. Simply:
 
-By default, all files ending in `.js` that are contained in the tests
-directory in the root of the project are run. If you want to run tests for
-all ACOS-related packages uncomment line: `./node_modules/acos*/tests/*.js`.
+  1. Install wdio CLI: `npm install @wdio/cli`
+  2. Interactive configuration: `./node_modules/.bin/wdio config`
+
+Required settings are the testing framework `mocha`,
+running synchronously `sync`
+and the base url `http://localhost:3000`.
+
+Running the config command will override configuration in `wdio.conf.js`.
+The preprepared config in ACOS repository finds test suites from project root
+(`./tests/*.js`) and from any ACOS packages (`./node_modules/acos-*/tests/*.js`).
+This can be altered in `specs` array in the `wdio.conf.js` file.
 
 # Writing Tests
 
 Examples of written tests can be found in `acos-jsparsons-python` module. For
-WebDriverIO details refer to the [WebDriverIO API Docs](http://webdriver.io/api.html).
+WebDriverIO details refer to the [WebDriverIO API Docs](https://webdriver.io/docs/api.html).

--- a/package.json
+++ b/package.json
@@ -23,8 +23,14 @@
     "serve-favicon": "^2.4.3"
   },
   "devDependencies": {
-    "webdriverio": "~3.4.0",
-    "chai": "~3.5.0"
+    "@wdio/cli": "^5.16.12",
+    "@wdio/local-runner": "^5.16.12",
+    "@wdio/mocha-framework": "^5.16.12",
+    "@wdio/spec-reporter": "^5.16.11",
+    "@wdio/sync": "^5.16.12",
+    "chai": "^4.2.0",
+    "chromedriver": "^78.0.1",
+    "wdio-chromedriver-service": "^5.0.2"
   },
   "repository": {
     "type": "git",

--- a/tests/basic-test.js
+++ b/tests/basic-test.js
@@ -1,14 +1,36 @@
-describe('Acos Server', function() {
-  describe('Acos frontpage', function() {
-    it('should load and display title', function() {
-      return browser
-        .url('http://localhost:3000')
-        .getTitle().should.eventually.be.equal('ACOS Server');
+var should = require('chai').should();
+
+describe('Acos Server', () => {
+
+  describe('Acos frontpage', () => {
+    browser.url('/');
+
+    it('should load and display title', () => {
+      browser.getTitle().should.equal('ACOS Server');
     });
-    
-    it('should display installed tools');
+
+    it('should display installed tools', () => {
+      let items = browser.$$('#installed_tools a').map(a => a.getText());
+      items.should.include('logging-keygenerator');
+    });
+
+    it('should display installed protocols', () => {
+      let items = browser.$$('#installed_protocols li').map(li => li.getText());
+      items.should.include('html');
+    });
+
+    it('should display installed content types', () => {
+      let items = browser.$$('#installed_content_types li').map(li => li.getText());
+      items.should.include('annotated');
+    });
+
+    it('should display installed content packages', () => {
+      let items = browser.$$('.contentPackage').map(p => p.$('.packageTitle').getText());
+      items.should.include('annotated-demo');
+    });
+
   });
-  
+
 });
 
 /*
@@ -39,10 +61,10 @@ describe('front page', function() {
   it('should list available tools', function() {
      assert.equal(this.browser.text('#installed_tools'), 'jsparsons-generator python-parser');
   });
-  
+
   it('should list available protocols', function() {
      assert.equal(this.browser.text('#installed_protocols'), 'aplus html pitt lti');
-  });  
+  });
 
   after(function(done) {
     this.server.close(done);

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -1,5 +1,15 @@
 exports.config = {
-
+    //
+    // ====================
+    // Runner Configuration
+    // ====================
+    //
+    // WebdriverIO allows it to run your tests in arbitrary locations (e.g. locally or
+    // on a remote machine).
+    runner: 'local',
+    //
+    // Override default path ('/wd/hub') for chromedriver service.
+    path: '/',
     //
     // ==================
     // Specify Test Files
@@ -11,8 +21,7 @@ exports.config = {
     //
     specs: [
         './tests/*.js',
-        // Uncomment following line to run tests for all Acos content packages/types
-        // './node_modules/acos*/tests/*.js'
+        './node_modules/acos-*/tests/*.js'
     ],
     // Patterns to exclude.
     exclude: [
@@ -22,18 +31,35 @@ exports.config = {
     // ============
     // Capabilities
     // ============
-    // Define your capabilities here. WebdriverIO can run multiple capabilties at the same
+    // Define your capabilities here. WebdriverIO can run multiple capabilities at the same
     // time. Depending on the number of capabilities, WebdriverIO launches several test
-    // sessions. Within your capabilities you can overwrite the spec and exclude option in
+    // sessions. Within your capabilities you can overwrite the spec and exclude options in
     // order to group specific specs to a specific capability.
+    //
+    // First, you can define how many instances should be started at the same time. Let's
+    // say you have 3 different capabilities (Chrome, Firefox, and Safari) and you have
+    // set maxInstances to 1; wdio will spawn 3 processes. Therefore, if you have 10 spec
+    // files and you set maxInstances to 10, all spec files will get tested at the same time
+    // and 30 processes will get spawned. The property handles how many capabilities
+    // from the same test should run tests.
+    //
+    maxInstances: 10,
     //
     // If you have trouble getting all important capabilities together, check out the
     // Sauce Labs platform configurator - a great tool to configure your capabilities:
     // https://docs.saucelabs.com/reference/platforms-configurator
     //
     capabilities: [{
-        //browserName: 'firefox'
-        browserName: 'chrome'
+        // maxInstances can get overwritten per capability. So if you have an in-house Selenium
+        // grid with only 5 firefox instances available you can make sure that not more than
+        // 5 instances get started at a time.
+        maxInstances: 5,
+        //
+        browserName: 'chrome',
+        // If outputDir is provided WebdriverIO can capture driver session logs
+        // it is possible to configure which logTypes to include/exclude.
+        // excludeDriverLogs: ['*'], // pass '*' to exclude all driver session logs
+        // excludeDriverLogs: ['bugreport', 'server'],
     }],
     //
     // ===================
@@ -41,96 +67,184 @@ exports.config = {
     // ===================
     // Define all options that are relevant for the WebdriverIO instance here
     //
-    // Level of logging verbosity: silent | verbose | command | data | result | error
-    logLevel: 'silent',
+    // Level of logging verbosity: trace | debug | info | warn | error | silent
+    logLevel: 'info',
     //
-    // Enables colors for log output.
-    coloredLogs: true,
-    //
-    // Saves a screenshot to a given path if a command fails.
-    screenshotPath: './errorShots/',
-    //
-    // Set a base URL in order to shorten url command calls. If your url parameter starts
-    // with "/", the base url gets prepended.
-    baseUrl: 'http://localhost:3000',
-    //
-    // Default timeout for all waitForXXX commands.
-    waitforTimeout: 10000,
-    //
-    // Initialize the browser instance with a WebdriverIO plugin. The object should have the
-    // plugin name as key and the desired plugin options as property. Make sure you have
-    // the plugin installed before running any tests. The following plugins are currently
-    // available:
-    // WebdriverCSS: https://github.com/webdriverio/webdrivercss
-    // WebdriverRTC: https://github.com/webdriverio/webdriverrtc
-    // Browserevent: https://github.com/webdriverio/browserevent
-    // plugins: {
-    //     webdrivercss: {
-    //         screenshotRoot: 'my-shots',
-    //         failedComparisonsRoot: 'diffs',
-    //         misMatchTolerance: 0.05,
-    //         screenWidth: [320,480,640,1024]
-    //     },
-    //     webdriverrtc: {},
-    //     browserevent: {}
+    // Set specific log levels per logger
+    // loggers:
+    // - webdriver, webdriverio
+    // - @wdio/applitools-service, @wdio/browserstack-service, @wdio/devtools-service, @wdio/sauce-service
+    // - @wdio/mocha-framework, @wdio/jasmine-framework
+    // - @wdio/local-runner, @wdio/lambda-runner
+    // - @wdio/sumologic-reporter
+    // - @wdio/cli, @wdio/config, @wdio/sync, @wdio/utils
+    // Level of logging verbosity: trace | debug | info | warn | error | silent
+    // logLevels: {
+    //     webdriver: 'info',
+    //     '@wdio/applitools-service': 'info'
     // },
     //
-    // Framework you want to run your specs with.
-    // The following are supported: mocha, jasmine and cucumber
-    // see also: http://webdriver.io/guide/testrunner/frameworks.html
+    // If you only want to run your tests until a specific amount of tests have failed use
+    // bail (default is 0 - don't bail, run all tests).
+    bail: 0,
     //
-    // Make sure you have the node package for the specific framework installed before running
-    // any tests. If not please install the following package:
-    // Mocha: `$ npm install mocha`
-    // Jasmine: `$ npm install jasmine`
-    // Cucumber: `$ npm install cucumber`
+    // Set a base URL in order to shorten url command calls. If your `url` parameter starts
+    // with `/`, the base url gets prepended, not including the path portion of your baseUrl.
+    // If your `url` parameter starts without a scheme or `/` (like `some/path`), the base url
+    // gets prepended directly.
+    baseUrl: 'http://localhost:3000',
+    //
+    // Default timeout for all waitFor* commands.
+    waitforTimeout: 10000,
+    //
+    // Default request retries count
+    connectionRetryCount: 3,
+    //
+    // Test runner services
+    // Services take over a specific job you don't want to take care of. They enhance
+    // your test setup with almost no effort. Unlike plugins, they don't add new
+    // commands. Instead, they hook themselves up into the test process.
+    services: ['chromedriver'],
+
+    // Framework you want to run your specs with.
+    // The following are supported: Mocha, Jasmine, and Cucumber
+    // see also: https://webdriver.io/docs/frameworks.html
+    //
+    // Make sure you have the wdio adapter package for the specific framework installed
+    // before running any tests.
     framework: 'mocha',
     //
+    // The number of times to retry the entire specfile when it fails as a whole
+    // specFileRetries: 1,
+    //
     // Test reporter for stdout.
-    // The following are supported: dot (default), spec and xunit
-    // see also: http://webdriver.io/guide/testrunner/reporters.html
-    reporter: 'spec',
+    // The only one supported by default is 'dot'
+    // see also: https://webdriver.io/docs/dot-reporter.html
+    reporters: ['spec'],
 
     //
     // Options to be passed to Mocha.
     // See the full list at http://mochajs.org/
     mochaOpts: {
-        ui: 'bdd'
+        ui: 'bdd',
+        timeout: 60000
     },
-
     //
     // =====
     // Hooks
     // =====
-    // Run functions before or after the test. If one of them returns with a promise, WebdriverIO
-    // will wait until that promise got resolved to continue.
-    //
-    // Gets executed before all workers get launched.
-    onPrepare: function() {
-        // do something
-    },
-    //
-    // Gets executed before test execution begins. At this point you will have access to all global
-    // variables like `browser`. It is the perfect place to define custom commands.
-    before: function() {
-        var chai = require('chai');
-        var chaiAsPromised = require('chai-as-promised');
+    // WebdriverIO provides several hooks you can use to interfere with the test process in order to enhance
+    // it and to build services around it. You can either apply a single function or an array of
+    // methods to it. If one of them returns with a promise, WebdriverIO will wait until that promise got
+    // resolved to continue.
+    /**
+     * Gets executed once before all workers get launched.
+     * @param {Object} config wdio configuration object
+     * @param {Array.<Object>} capabilities list of capabilities details
+     */
+    // onPrepare: function (config, capabilities) {
+    // },
+    /**
+     * Gets executed just before initialising the webdriver session and test framework. It allows you
+     * to manipulate configurations depending on the capability or spec.
+     * @param {Object} config wdio configuration object
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {Array.<String>} specs List of spec file paths that are to be run
+     */
+    // beforeSession: function (config, capabilities, specs) {
+    // },
+    /**
+     * Gets executed before test execution begins. At this point you can access to all global
+     * variables like `browser`. It is the perfect place to define custom commands.
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {Array.<String>} specs List of spec file paths that are to be run
+     */
+    // before: function (capabilities, specs) {
+    // },
+    /**
+     * Runs before a WebdriverIO command gets executed.
+     * @param {String} commandName hook command name
+     * @param {Array} args arguments that command would receive
+     */
+    // beforeCommand: function (commandName, args) {
+    // },
+    /**
+     * Hook that gets executed before the suite starts
+     * @param {Object} suite suite details
+     */
+    // beforeSuite: function (suite) {
+    // },
+    /**
+     * Function to be executed before a test (in Mocha/Jasmine) starts.
+     */
+    // beforeTest: function (test, context) {
+    // },
+    /**
+     * Hook that gets executed _before_ a hook within the suite starts (e.g. runs before calling
+     * beforeEach in Mocha)
+     */
+    // beforeHook: function (test, context) {
+    // },
+    /**
+     * Hook that gets executed _after_ a hook within the suite starts (e.g. runs after calling
+     * afterEach in Mocha)
+     */
+    // afterHook: function (test, context, { error, result, duration, passed, retries }) {
+    // },
+    /**
+     * Function to be executed after a test (in Mocha/Jasmine).
+     */
+    // afterTest: function(test, context, { error, result, duration, passed, retries }) {
+    // },
 
-        chai.use(chaiAsPromised);
-        expect = chai.expect;
-        chai.Should();
 
-    },
-    //
-    // Gets executed after all tests are done. You still have access to all global variables from
-    // the test.
-    after: function(failures, pid) {
-        // do something
-    },
-    //
-    // Gets executed after all workers got shut down and the process is about to exit. It is not
-    // possible to defer the end of the process using a promise.
-    onComplete: function() {
-        // do something
-    }
-};
+    /**
+     * Hook that gets executed after the suite has ended
+     * @param {Object} suite suite details
+     */
+    // afterSuite: function (suite) {
+    // },
+    /**
+     * Runs after a WebdriverIO command gets executed
+     * @param {String} commandName hook command name
+     * @param {Array} args arguments that command would receive
+     * @param {Number} result 0 - command success, 1 - command error
+     * @param {Object} error error object if any
+     */
+    // afterCommand: function (commandName, args, result, error) {
+    // },
+    /**
+     * Gets executed after all tests are done. You still have access to all global variables from
+     * the test.
+     * @param {Number} result 0 - test pass, 1 - test fail
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {Array.<String>} specs List of spec file paths that ran
+     */
+    // after: function (result, capabilities, specs) {
+    // },
+    /**
+     * Gets executed right after terminating the webdriver session.
+     * @param {Object} config wdio configuration object
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {Array.<String>} specs List of spec file paths that ran
+     */
+    // afterSession: function (config, capabilities, specs) {
+    // },
+    /**
+     * Gets executed after all workers got shut down and the process is about to exit. An error
+     * thrown in the onComplete hook will result in the test run failing.
+     * @param {Object} exitCode 0 - success, 1 - fail
+     * @param {Object} config wdio configuration object
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {<Object>} results object containing test results
+     */
+    // onComplete: function(exitCode, config, capabilities, results) {
+    // },
+    /**
+    * Gets executed when a refresh happens.
+    * @param {String} oldSessionId session ID of the old session
+    * @param {String} newSessionId session ID of the new session
+    */
+    //onReload: function(oldSessionId, newSessionId) {
+    //}
+}


### PR DESCRIPTION
The current testing facilities were not working in my environment. I proceeded reading the latest docs and refactored. Note that tests in acos-jsparsons-python and acos-jsparsons-python-custom should also be upgraded.