### PR TITLE
Implement live reloading with livereload+nodemon

### DIFF
--- a/config.js
+++ b/config.js
@@ -22,6 +22,10 @@ var CONFIG = {
     // the package name must start with 'acos-'.
     autoDiscovery: true,
 
+
+    // Default port used by the connect-livereload package
+    connectLiveReloadPort: 35729,
+
     // Insert all the installed package names here to use them
     // These are ignored if autoDiscovery is true!
     installedPackages: [

--- a/package.json
+++ b/package.json
@@ -1,8 +1,20 @@
 {
   "name": "acos-server",
   "version": "0.2.3",
+  "nodemonConfig": {
+    "ignoreRoot": [
+      ".git"
+    ],
+    "ext": "xml, json, js, html, css",
+    "ignore": [
+      "test/*",
+      "docs/*"
+    ],
+    "delay": "1000"
+  },
   "scripts": {
-    "start": "node ./bin/www"
+    "start": "node ./bin/www",
+    "dev": "nodemon ./bin/www"
   },
   "dependencies": {
     "acos-annotated": "^0.2.0",
@@ -30,6 +42,9 @@
     "@wdio/sync": "^5.16.12",
     "chai": "^4.2.0",
     "chromedriver": "^78.0.1",
+    "connect-livereload": "^0.6.1",
+    "livereload": "^0.9.1",
+    "nodemon": "^2.0.4",
     "wdio-chromedriver-service": "^5.0.2"
   },
   "repository": {


### PR DESCRIPTION
Anytime an Acos exercise is edited, nodemon will reset the server, while livereload will refresh the font-end and browser. it will help improve the experience of developing new Acos exercises.

**This PR overwrite the PR** #14 

Examples:

![XMLchanges](https://user-images.githubusercontent.com/10437475/93117954-39183000-f6c8-11ea-9903-c0ef59552a84.gif)

![jsonchanges](https://user-images.githubusercontent.com/10437475/93118009-47664c00-f6c8-11ea-91d1-9c773d4d9c01.gif)

